### PR TITLE
fix sqlite support

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -15,8 +15,11 @@ try:
 except KeyError:
     raise BaseException("Unknown database engine {}".format(config.get("db_engine")))
 
-db = engine(config.get("db_name"), user=config.get('db_user'), password=config.get("db_password"),
-            host=config.get("db_host"), port=int(config.get("db_port")))
+if engine == PooledSqliteDatabase:
+    db = engine(config.get("db_name"))
+else:
+    db = engine(config.get("db_name"), user=config.get('db_user'), password=config.get("db_password"),
+                host=config.get("db_host"), port=int(config.get("db_port")))
 
 
 class BaseModel(Model):


### PR DESCRIPTION
There might be a cleaner way to do this, rather than compare classes, so I'm open to suggestions. `PooledSqliteDatabase` doesn't take any extra parameters (ie. `user`).