### PR TITLE
Add the user's Python version to the list of metadata that can be sen…

### DIFF
--- a/lib/database.py
+++ b/lib/database.py
@@ -43,7 +43,7 @@ class Crash(BaseModel):
     stack = TextField()
     description = TextField()
     locale = CharField(max_length=5, default="")
-    python_version = CharField()
+    python_version = CharField(default='')
 
 
 class LogEntry(BaseModel):
@@ -54,11 +54,11 @@ class LogEntry(BaseModel):
 def create_tables():
     db.create_tables([CrashKind, Crash, LogEntry], safe=True)
 
+    # This will error if the column has already been added.
     try:
         migrator = migrator_class(db)
         migrate(
             migrator.add_column('Crash', 'python_version', CharField(default='')),
         )
     except OperationalError as e:
-        if e.args != ("duplicate column name: python_version",):
-            raise e
+        pass

--- a/lib/database.py
+++ b/lib/database.py
@@ -1,16 +1,17 @@
 import datetime
 
 from playhouse.pool import PooledPostgresqlDatabase, PooledMySQLDatabase, PooledSqliteDatabase
-from peewee import Model, TextField, DateTimeField
+from playhouse.migrate import migrate, PostgresqlMigrator, SqliteMigrator, MySQLMigrator
+from peewee import Model, TextField, DateTimeField, OperationalError
 from peewee import CharField, ForeignKeyField, IntegerField
 
 from lib import config
 
 try:
-    engine = {
-        "postgres": PooledPostgresqlDatabase,
-        "mysql": PooledMySQLDatabase,
-        "sqlite": PooledSqliteDatabase
+    engine, migrator_class = {
+        "postgres": (PooledPostgresqlDatabase, PostgresqlMigrator),
+        "mysql": (PooledMySQLDatabase, MySQLMigrator),
+        "sqlite": (PooledSqliteDatabase, SqliteMigrator),
     }[config.get("db_engine", default="postgres")]
 except KeyError:
     raise BaseException("Unknown database engine {}".format(config.get("db_engine")))
@@ -20,7 +21,6 @@ if engine == PooledSqliteDatabase:
 else:
     db = engine(config.get("db_name"), user=config.get('db_user'), password=config.get("db_password"),
                 host=config.get("db_host"), port=int(config.get("db_port")))
-
 
 class BaseModel(Model):
     class Meta:
@@ -43,6 +43,7 @@ class Crash(BaseModel):
     stack = TextField()
     description = TextField()
     locale = CharField(max_length=5, default="")
+    python_version = CharField()
 
 
 class LogEntry(BaseModel):
@@ -52,3 +53,12 @@ class LogEntry(BaseModel):
 
 def create_tables():
     db.create_tables([CrashKind, Crash, LogEntry], safe=True)
+
+    try:
+        migrator = migrator_class(db)
+        migrate(
+            migrator.add_column('Crash', 'python_version', CharField(default='')),
+        )
+    except OperationalError as e:
+        if e.args != ("duplicate column name: python_version",):
+            raise e

--- a/lib/issues.py
+++ b/lib/issues.py
@@ -41,10 +41,7 @@ def format_issue(kind_id):
     reporter_table = ""
     additional = []
     for c in crashes:
-        reporter_dict = model_to_dict(c)
-        if "python_version" not in reporter_dict:
-            reporter_dict["python_version"] = "-"
-        reporter_table += reporter_row.format(**reporter_dict)
+        reporter_table += reporter_row.format(**model_to_dict(c))
         if c.description:
             additional.append(c.description)
     v = {

--- a/lib/issues.py
+++ b/lib/issues.py
@@ -20,8 +20,8 @@ Reporter
 
 This issue was reported by {user_count} user(s):
 
-| Electrum Version  | Operating System  | Wallet Type  | Locale |
-|---|---|---|---|
+| Electrum Version  | Python Version | Operating System  | Wallet Type  | Locale |
+|---|---|---|---|---|
 {reporter_table}
 
 Additional Information
@@ -29,7 +29,7 @@ Additional Information
 
 """
 
-reporter_row = """| {app_version}  | {os} | {wallet_type} | {locale} |
+reporter_row = """| {app_version}  | {python_version} | {os} | {wallet_type} | {locale} |
 """
 
 no_info = "The reporting user(s) did not provide additional information."
@@ -41,7 +41,10 @@ def format_issue(kind_id):
     reporter_table = ""
     additional = []
     for c in crashes:
-        reporter_table += reporter_row.format(**model_to_dict(c))
+        reporter_dict = model_to_dict(c)
+        if "python_version" not in reporter_dict:
+            reporter_dict["python_version"] = "-"
+        reporter_table += reporter_row.format(**reporter_dict)
         if c.description:
             additional.append(c.description)
     v = {


### PR DESCRIPTION
…t from either Electrum or Electron Cash.

Electron Cash already supports it in it's master branch.

1. If 'python_version' is pushed and a crashhub instance is the current master code, it is ignored.
2. If 'python_version' is not pushed and a crashhub instance is this pull request branch, [it is defaulted to '-'](https://github.com/rt121212121/electrum/issues/2).
3. If 'python_version' is pushed and a crashhub instance is this pull request branch, [it gets stored correctly](https://github.com/rt121212121/electrum/issues/3).

I've inlined the migration in the `create_db`, and caught the error from running it consecutively, as I'm not sure how to do the migration.

I tested with Sqlite, running locally.